### PR TITLE
Refactor S3DataSourceSpec

### DIFF
--- a/datasource/src/test/scala/quasar/physical/s3/S3DataSourceSpec.scala
+++ b/datasource/src/test/scala/quasar/physical/s3/S3DataSourceSpec.scala
@@ -31,7 +31,6 @@ import cats.data.OptionT
 import fs2.Stream
 import org.http4s.Uri
 import org.http4s.client.blaze.Http1Client
-import scalaz.syntax.applicative._
 import scalaz.{Id, ~>}, Id.Id
 import shims._
 


### PR DESCRIPTION
Main changes:
- structure the tests per API function that is under test
- split test case for evaluate in 2 and verify the exact contents