### PR TITLE
Raise PathNotFound when attempting to read non-existent file.

### DIFF
--- a/datasource/src/main/scala/quasar/physical/s3/S3DataSource.scala
+++ b/datasource/src/main/scala/quasar/physical/s3/S3DataSource.scala
@@ -29,6 +29,7 @@ import slamdata.Predef.{Stream => _, _}
 
 import java.time.{OffsetDateTime, ZoneOffset, LocalDateTime}
 
+import cats.data.OptionT
 import cats.effect.Effect
 import cats.syntax.applicative._
 import cats.syntax.flatMap._
@@ -42,7 +43,7 @@ import pathy.Path
 import pathy.Path.{DirName, FileName}
 import qdata.QDataEncode
 import qdata.json.QDataFacade
-import scalaz.{\/-, -\/, OptionT}
+import scalaz.{\/-, -\/}
 import shims._
 
 final class S3DataSource[F[_]: Effect: MonadResourceErr](

--- a/datasource/src/main/scala/quasar/physical/s3/S3DataSource.scala
+++ b/datasource/src/main/scala/quasar/physical/s3/S3DataSource.scala
@@ -60,7 +60,7 @@ final class S3DataSource[F[_]: Effect: MonadResourceErr](
       def evaluate(path: ResourcePath): F[Stream[F, R]] =
         path match {
           case Root =>
-            Stream.eval[F, R](MR.raiseError(ResourceError.notAResource(path))).pure[F]
+            MR.raiseError(ResourceError.notAResource(path))
           case Leaf(file) =>
             impl.evaluate[F, R](config.parsing, client, config.bucket, file, signRequest(config))
         }

--- a/datasource/src/main/scala/quasar/physical/s3/S3DataSource.scala
+++ b/datasource/src/main/scala/quasar/physical/s3/S3DataSource.scala
@@ -60,13 +60,9 @@ final class S3DataSource[F[_]: Effect: MonadResourceErr](
       def evaluate(path: ResourcePath): F[Stream[F, R]] =
         path match {
           case Root =>
-            Stream.empty.covaryAll[F, R].pure[F]
+            Stream.eval[F, R](MR.raiseError(ResourceError.notAResource(path))).pure[F]
           case Leaf(file) =>
-            impl.evaluate[F, R](config.parsing, client, config.bucket, file, signRequest(config)) map {
-              case None =>
-                Stream.eval(MR.raiseError(ResourceError.pathNotFound(path)))
-              case Some(s) => s
-            }
+            impl.evaluate[F, R](config.parsing, client, config.bucket, file, signRequest(config))
         }
     }
 

--- a/datasource/src/test/scala/quasar/physical/s3/S3DataSourceSpec.scala
+++ b/datasource/src/test/scala/quasar/physical/s3/S3DataSourceSpec.scala
@@ -134,12 +134,12 @@ class S3DataSourceSpec extends DatasourceSpec[IO, Stream[IO, ?]] {
 
     "reading a non-existent file raises ResourceError.PathNotFound" >> {
       val creds = EitherT.right[Throwable](credentials)
-      val ds = creds.flatMap(c => mkDatasource[G](S3JsonParsing.JsonArray, testBucket, c))
+      val ds = creds.flatMap(mkDatasource[G](S3JsonParsing.JsonArray, testBucket, _))
 
       val path = ResourcePath.root() / ResourceName("does-not-exist")
-      val read: Stream[G, Data] = Stream.force(ds.flatMap(_.evaluator[Data].evaluate(path)))
+      val read: G[Stream[G, Data]] = ds.flatMap(_.evaluator[Data].evaluate(path))
 
-      read.compile.toList.value.unsafeRunSync must beLeft.like {
+      run(read.value) must beLeft.like {
         case ResourceError.throwableP(ResourceError.PathNotFound(_)) => ok
       }
     }


### PR DESCRIPTION
The previous implementation raised the error using `Stream.eval`, which didn't work. This is more straightforward and removes the partiality in the `evaluate` impl.