### PR TITLE
s/DataSource/Datasource for consistency with quasar

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ For BSD (or macOS) `base64`:
 base64 -D -i testCredentials.json.b64 -o testCredentials.json
 ```
 
-After this, you should be able to run the `SecureS3DataSourceSpec` spec
+After this, you should be able to run the `SecureS3DatasourceSpec` spec
 
 
 ## Thanks to Sponsors

--- a/build.sbt
+++ b/build.sbt
@@ -146,7 +146,7 @@ lazy val root = project.in(file("."))
 // Quasar needs to know where the DataSourceModule for the connector is
 lazy val manifestSettings =
   packageOptions in (Compile, packageBin) +=
-    Package.ManifestAttributes("DataSource-Module" -> "quasar.physical.s3.S3DataSourceModule$")
+    Package.ManifestAttributes("Datasource-Module" -> "quasar.physical.s3.S3DatasourceModule$")
 
 /** Lightweight connector module.
   */

--- a/build.sbt
+++ b/build.sbt
@@ -143,7 +143,7 @@ lazy val root = project.in(file("."))
 
 // common components
 
-// Quasar needs to know where the DataSourceModule for the connector is
+// Quasar needs to know where the DatasourceModule for the connector is
 lazy val manifestSettings =
   packageOptions in (Compile, packageBin) +=
     Package.ManifestAttributes("Datasource-Module" -> "quasar.physical.s3.S3DatasourceModule$")

--- a/datasource/src/main/scala/quasar/physical/s3/S3Datasource.scala
+++ b/datasource/src/main/scala/quasar/physical/s3/S3Datasource.scala
@@ -45,7 +45,7 @@ import qdata.json.QDataFacade
 import scalaz.{\/-, -\/, OptionT}
 import shims._
 
-final class S3DataSource[F[_]: Effect: MonadResourceErr](
+final class S3Datasource[F[_]: Effect: MonadResourceErr](
   client: Client[F],
   config: S3Config)
     extends LightweightDatasource[F, Stream[F, ?]] {
@@ -106,10 +106,10 @@ final class S3DataSource[F[_]: Effect: MonadResourceErr](
     }
 
   private def signRequest(c: S3Config): Request[F] => F[Request[F]] =
-    S3DataSource.signRequest(c)
+    S3Datasource.signRequest(c)
 }
 
-object S3DataSource {
+object S3Datasource {
   def signRequest[F[_]: Effect](c: S3Config): Request[F] => F[Request[F]] =
     c.credentials match {
       case Some(creds) => {

--- a/datasource/src/main/scala/quasar/physical/s3/S3DatasourceModule.scala
+++ b/datasource/src/main/scala/quasar/physical/s3/S3DatasourceModule.scala
@@ -38,7 +38,7 @@ import cats.syntax.option._
 import shims._
 import slamdata.Predef.{Stream => _, _}
 
-object S3DataSourceModule extends LightweightDatasourceModule {
+object S3DatasourceModule extends LightweightDatasourceModule {
   def kind: DatasourceType = s3.datasourceKind
 
   def lightweightDatasource[F[_]: ConcurrentEffect: MonadResourceErr: Timer](config: Json)
@@ -46,7 +46,7 @@ object S3DataSourceModule extends LightweightDatasourceModule {
     config.as[S3Config].result match {
       case Right(s3Config) => {
         Http1Client[F]() flatMap { client =>
-          val s3Ds = new S3DataSource[F](client, s3Config)
+          val s3Ds = new S3Datasource[F](client, s3Config)
           val ds: Datasource[F, Stream[F, ?], ResourcePath] = s3Ds
 
           s3Ds.isLive.ifM({

--- a/datasource/src/test/scala/quasar/physical/s3/S3DatasourceModuleSpec.scala
+++ b/datasource/src/test/scala/quasar/physical/s3/S3DatasourceModuleSpec.scala
@@ -29,8 +29,8 @@ import cats.effect.IO
 import org.specs2.mutable.Specification
 import shims._
 
-class S3DataSourceModuleSpec extends Specification {
-  import S3DataSourceModuleSpec._
+class S3DatasourceModuleSpec extends Specification {
+  import S3DatasourceModuleSpec._
 
   "rejects invalid credentials" >> {
     // slamdata-private-test is a bucket that requires credentials to access
@@ -38,7 +38,7 @@ class S3DataSourceModuleSpec extends Specification {
       "bucket" -> Json.jString("https://s3.amazonaws.com/slamdata-private-test"),
       "jsonParsing" -> Json.jString("array"))
 
-    val ds = S3DataSourceModule.lightweightDatasource[IO](conf).unsafeRunSync.toEither
+    val ds = S3DatasourceModule.lightweightDatasource[IO](conf).unsafeRunSync.toEither
 
     ds must beLike {
       case Left(AccessDenied(_, _, _)) => ok
@@ -50,7 +50,7 @@ class S3DataSourceModuleSpec extends Specification {
       "bucket" -> Json.jString("https://example.com"),
       "jsonParsing" -> Json.jString("array"))
 
-    val ds = S3DataSourceModule.lightweightDatasource[IO](conf).unsafeRunSync.toEither
+    val ds = S3DatasourceModule.lightweightDatasource[IO](conf).unsafeRunSync.toEither
 
     ds must beLike {
       case Left(AccessDenied(_, _, _)) => ok
@@ -74,7 +74,7 @@ class S3DataSourceModuleSpec extends Specification {
         "secretKey" -> Json.jString("<REDACTED>"),
         "region" -> Json.jString("<REDACTED>")))
 
-    S3DataSourceModule.sanitizeConfig(conf) must_== redactedConf
+    S3DatasourceModule.sanitizeConfig(conf) must_== redactedConf
   }
 
   "does nothing when there are no credentials to redact" >> {
@@ -82,11 +82,11 @@ class S3DataSourceModuleSpec extends Specification {
       "bucket" -> Json.jString("https://some.bucket.uri"),
       "jsonParsing" -> Json.jString("array"))
 
-    S3DataSourceModule.sanitizeConfig(conf) must_== conf
+    S3DatasourceModule.sanitizeConfig(conf) must_== conf
   }
 }
 
-object S3DataSourceModuleSpec {
+object S3DatasourceModuleSpec {
   implicit val ioMonadResourceErr: MonadError_[IO, ResourceError] =
     MonadError_.facet[IO](ResourceError.throwableP)
 }

--- a/datasource/src/test/scala/quasar/physical/s3/S3DatasourceSpec.scala
+++ b/datasource/src/test/scala/quasar/physical/s3/S3DatasourceSpec.scala
@@ -34,9 +34,9 @@ import org.http4s.client.blaze.Http1Client
 import scalaz.{Id, ~>}, Id.Id
 import shims._
 
-import S3DataSourceSpec._
+import S3DatasourceSpec._
 
-class S3DataSourceSpec extends DatasourceSpec[IO, Stream[IO, ?]] {
+class S3DatasourceSpec extends DatasourceSpec[IO, Stream[IO, ?]] {
   val testBucket = Uri.uri("https://s3.amazonaws.com/slamdata-public-test")
   val nonExistentPath =
     ResourcePath.root() / ResourceName("does") / ResourceName("not") / ResourceName("exist")
@@ -169,13 +169,13 @@ class S3DataSourceSpec extends DatasourceSpec[IO, Stream[IO, ?]] {
     creds: Option[S3Credentials])
       : F[Datasource[F, Stream[F, ?], ResourcePath]] =
     Http1Client[F]().map(client =>
-     new S3DataSource[F](client, S3Config(bucket, parsing, creds)))
+      new S3Datasource[F](client, S3Config(bucket, parsing, creds)))
 
   val datasourceLD = run(mkDatasource[IO](S3JsonParsing.LineDelimited, testBucket, None))
   val datasource = run(mkDatasource[IO](S3JsonParsing.JsonArray, testBucket, None))
 }
 
-object S3DataSourceSpec {
+object S3DatasourceSpec {
   type G[A] = EitherT[IO, Throwable, A]
 
   implicit val ioMonadResourceErr: MonadError_[IO, ResourceError] =

--- a/datasource/src/test/scala/quasar/physical/s3/SecureS3DatasourceSpec.scala
+++ b/datasource/src/test/scala/quasar/physical/s3/SecureS3DatasourceSpec.scala
@@ -33,9 +33,9 @@ import cats.syntax.option._
 import org.http4s.Uri
 import shims._
 
-import SecureS3DataSourceSpec._
+import SecureS3DatasourceSpec._
 
-final class SecureS3DataSourceSpec extends S3DataSourceSpec {
+final class SecureS3DatasourceSpec extends S3DatasourceSpec {
   override val testBucket = Uri.uri("https://s3.amazonaws.com/slamdata-private-test")
 
   // FIXME: close the file once we update to cats-effect 1.0.0 and
@@ -60,7 +60,7 @@ final class SecureS3DataSourceSpec extends S3DataSourceSpec {
     run(credentials >>= (creds => mkDatasource[IO](S3JsonParsing.JsonArray, testBucket, creds)))
 }
 
-object SecureS3DataSourceSpec {
+object SecureS3DatasourceSpec {
   implicit val ioMonadResourceErr: MonadError_[IO, ResourceError] =
     MonadError_.facet[IO](ResourceError.throwableP)
 }


### PR DESCRIPTION
Long overdue. This changes the manifest attribute from `DataSource-Module` to be `Datasource-Module`, so this is technically `breaking`. However, the launcher/frontend should be unaffected since they do their own thing and don't use `assembleDatasource`.