### PR TITLE
Handle redirects

### DIFF
--- a/datasource/src/main/scala/quasar/physical/s3/RequestSigning.scala
+++ b/datasource/src/main/scala/quasar/physical/s3/RequestSigning.scala
@@ -221,9 +221,6 @@ object AwsV4Signing {
           } yield signing
 
           req => {
-            println("-------------------------------------------")
-            println(s"Request: $req")
-            println("-------------------------------------------")
             // Requests that require signing also require `host` to always be present
             val req0 = req.uri.host match {
               case Some(host) => req.withHeaders(Headers(Header("host", host.value)))

--- a/datasource/src/main/scala/quasar/physical/s3/RequestSigning.scala
+++ b/datasource/src/main/scala/quasar/physical/s3/RequestSigning.scala
@@ -221,6 +221,9 @@ object AwsV4Signing {
           } yield signing
 
           req => {
+            println("-------------------------------------------")
+            println(s"Request: $req")
+            println("-------------------------------------------")
             // Requests that require signing also require `host` to always be present
             val req0 = req.uri.host match {
               case Some(host) => req.withHeaders(Headers(Header("host", host.value)))

--- a/datasource/src/main/scala/quasar/physical/s3/S3Datasource.scala
+++ b/datasource/src/main/scala/quasar/physical/s3/S3Datasource.scala
@@ -85,7 +85,7 @@ final class S3Datasource[F[_]: Effect: MonadResourceErr](
 
   def isLive: F[Liveness] = {
     val listing = OptionT(prefixedChildPaths(ResourcePath.Root)).isDefined
-    val live = impl.isLive(client, config)
+    val live = impl.preflightCheck(client, config)
 
     (listing, live).mapN {
       case (true, None) => Liveness.live

--- a/datasource/src/main/scala/quasar/physical/s3/impl/children.scala
+++ b/datasource/src/main/scala/quasar/physical/s3/impl/children.scala
@@ -152,7 +152,7 @@ object children {
     val ct0 = ct.map(_.value).map(("continuation-token", _))
 
     val q = Query.fromString(s3EncodeQueryParams(
-      List(delimiter, listType, prefix, ct0).unite.toMap))
+      List(listType, delimiter, prefix, ct0).unite.toMap))
 
     Request[F](uri = listingQuery.copy(query = q))
   }

--- a/datasource/src/main/scala/quasar/physical/s3/impl/evaluate.scala
+++ b/datasource/src/main/scala/quasar/physical/s3/impl/evaluate.scala
@@ -34,12 +34,8 @@ import shims._
 
 object evaluate {
 
-  def apply[F[_]: Effect](
-      client: Client[F],
-      uri: Uri,
-      file: AFile,
-      sign: Request[F] => F[Request[F]])
-      (implicit MR: MonadResourceErr[F])
+  def apply[F[_]: Effect](client: Client[F], uri: Uri, file: AFile)
+    (implicit MR: MonadResourceErr[F])
       : F[Stream[F, Byte]] = {
     // Convert the pathy Path to a POSIX path, dropping
     // the first slash, which is what S3 expects for object paths
@@ -48,7 +44,7 @@ object evaluate {
     val queryUri = appendPathS3Encoded(uri, objectPath)
     val request = Request[F](uri = queryUri)
 
-    sign(request) >>= (streamRequest[F, Byte](client, _, file)(_.body))
+    streamRequest[F, Byte](client, request, file)(_.body)
   }
 
   ////

--- a/datasource/src/main/scala/quasar/physical/s3/impl/isLive.scala
+++ b/datasource/src/main/scala/quasar/physical/s3/impl/isLive.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.physical.s3.impl
+
+import quasar.physical.s3.S3Config
+
+import slamdata.Predef._
+
+import cats.Applicative
+import cats.syntax.applicative._
+import cats.syntax.option._
+import org.http4s.client.Client
+import org.http4s.headers.Location
+import org.http4s.{Method, Request, Status}
+
+object isLive {
+  def apply[F[_]: Applicative](client: Client[F], config: S3Config): F[Option[S3Config]] = {
+    client.fetch(Request[F](uri = config.bucket, method = Method.HEAD))(resp => resp.status match {
+      case Status.Ok => none.pure[F]
+      case Status.MovedPermanently => resp.headers.get(Location) match {
+        case Some(loc) => config.copy(bucket = loc.uri).some.pure[F]
+        case None => none.pure[F]
+      }
+      case _ => none.pure[F]
+    })
+  }
+}

--- a/datasource/src/main/scala/quasar/physical/s3/impl/isResource.scala
+++ b/datasource/src/main/scala/quasar/physical/s3/impl/isResource.scala
@@ -51,16 +51,16 @@ object isResource {
     if (Path.identicalPath(Path.rootDir, file)) {
       false.pure[F]
     } else {
+      println("Got here")
       // Don't use the metadata, just check the request status
-      sign(request) >>= (r =>
-        client.status(r) >>= {
-          case Status.Ok => true.pure[F]
-          case Status.PartialContent => true.pure[F]
-          case Status.NotFound => false.pure[F]
-          case Status.RangeNotSatisfiable => false.pure[F]
-          case Status.Forbidden => Effect[F].raiseError(new Exception(s"Permission denied. Make sure you have access to the configured bucket"))
-          case s => Effect[F].raiseError(new Exception(s"Unexpected status returned during `isResource` call: $s"))
-        })
+      sign(request) >>= (client.status(_)) >>= {
+        case Status.Ok => true.pure[F]
+        case Status.PartialContent => true.pure[F]
+        case Status.NotFound => false.pure[F]
+        case Status.RangeNotSatisfiable => false.pure[F]
+        case Status.Forbidden => Effect[F].raiseError(new Exception(s"Permission denied. Make sure you have access to the configured bucket"))
+        case s => Effect[F].raiseError(new Exception(s"Unexpected status returned during `isResource` call: $s"))
+      }
     }
   }
 }

--- a/datasource/src/main/scala/quasar/physical/s3/impl/isResource.scala
+++ b/datasource/src/main/scala/quasar/physical/s3/impl/isResource.scala
@@ -51,16 +51,16 @@ object isResource {
     if (Path.identicalPath(Path.rootDir, file)) {
       false.pure[F]
     } else {
-      println("Got here")
       // Don't use the metadata, just check the request status
-      sign(request) >>= (client.status(_)) >>= {
-        case Status.Ok => true.pure[F]
-        case Status.PartialContent => true.pure[F]
-        case Status.NotFound => false.pure[F]
-        case Status.RangeNotSatisfiable => false.pure[F]
-        case Status.Forbidden => Effect[F].raiseError(new Exception(s"Permission denied. Make sure you have access to the configured bucket"))
-        case s => Effect[F].raiseError(new Exception(s"Unexpected status returned during `isResource` call: $s"))
-      }
+      sign(request) >>= (r =>
+        client.status(r) >>= {
+          case Status.Ok => true.pure[F]
+          case Status.PartialContent => true.pure[F]
+          case Status.NotFound => false.pure[F]
+          case Status.RangeNotSatisfiable => false.pure[F]
+          case Status.Forbidden => Effect[F].raiseError(new Exception(s"Permission denied. Make sure you have access to the configured bucket"))
+          case s => Effect[F].raiseError(new Exception(s"Unexpected status returned during `isResource` call: $s"))
+        })
     }
   }
 }

--- a/datasource/src/main/scala/quasar/physical/s3/impl/preflightCheck.scala
+++ b/datasource/src/main/scala/quasar/physical/s3/impl/preflightCheck.scala
@@ -27,7 +27,7 @@ import org.http4s.client.Client
 import org.http4s.headers.Location
 import org.http4s.{Method, Request, Status}
 
-object isLive {
+object preflightCheck {
   def apply[F[_]: Applicative](client: Client[F], config: S3Config): F[Option[S3Config]] = {
     client.fetch(Request[F](uri = config.bucket, method = Method.HEAD))(resp => resp.status match {
       case Status.Ok => none.pure[F]

--- a/datasource/src/test/scala/quasar/physical/s3/S3DatasourceSpec.scala
+++ b/datasource/src/test/scala/quasar/physical/s3/S3DatasourceSpec.scala
@@ -211,10 +211,10 @@ class S3DatasourceSpec extends DatasourceSpec[IO, Stream[IO, ?]] {
     val ec = ExecutionContext.Implicits.global
     val builder = BlazeClientBuilder[F](ec)
     val client = unsafeResource(builder.resource)
-    val redirectClient = client.map(FollowRedirect(3)(_))
-    val signingClient = redirectClient.map(AwsV4Signing(testConfig))
+    val signingClient = client.map(AwsV4Signing(testConfig))
+    val redirectClient = signingClient.map(FollowRedirect(3)(_))
 
-    signingClient map (new S3Datasource[F](_, S3Config(bucket, parsing, creds)))
+    redirectClient map (new S3Datasource[F](_, S3Config(bucket, parsing, creds)))
   }
 
   val datasourceLD = run(mkDatasource[IO](S3JsonParsing.LineDelimited, testBucket, None))

--- a/datasource/src/test/scala/quasar/physical/s3/S3DatasourceSpec.scala
+++ b/datasource/src/test/scala/quasar/physical/s3/S3DatasourceSpec.scala
@@ -33,7 +33,6 @@ import cats.syntax.applicative._
 import cats.syntax.functor._
 import fs2.Stream
 import org.http4s.client.blaze.BlazeClientBuilder
-import org.http4s.client.middleware.FollowRedirect
 import org.http4s.Uri
 import scalaz.{Id, ~>}, Id.Id
 import shims._
@@ -212,9 +211,8 @@ class S3DatasourceSpec extends DatasourceSpec[IO, Stream[IO, ?]] {
     val builder = BlazeClientBuilder[F](ec)
     val client = unsafeResource(builder.resource)
     val signingClient = client.map(AwsV4Signing(testConfig))
-    val redirectClient = signingClient.map(FollowRedirect(3)(_))
 
-    redirectClient map (new S3Datasource[F](_, S3Config(bucket, parsing, creds)))
+    signingClient map (new S3Datasource[F](_, S3Config(bucket, parsing, creds)))
   }
 
   val datasourceLD = run(mkDatasource[IO](S3JsonParsing.LineDelimited, testBucket, None))

--- a/datasource/src/test/scala/quasar/physical/s3/impl/ChildrenSpec.scala
+++ b/datasource/src/test/scala/quasar/physical/s3/impl/ChildrenSpec.scala
@@ -22,8 +22,7 @@ import scala.concurrent.ExecutionContext
 
 import cats.effect.IO
 import cats.data.OptionT
-import cats.syntax.applicative._
-import org.http4s.{Uri, Request}
+import org.http4s.Uri
 import org.http4s.client.blaze.BlazeClientBuilder
 import org.specs2.mutable.Specification
 import pathy.Path
@@ -36,10 +35,9 @@ final class ChildrenSpec extends Specification {
     val bucket = Uri.uri("https://s3.amazonaws.com/slamdata-public-test/").withQueryParam("max-keys", "1")
 
     val dir = Path.rootDir
-    val sign: Request[IO] => IO[Request[IO]] = _.pure[IO]
     val client = BlazeClientBuilder[IO](ExecutionContext.global).resource
 
-    OptionT(client.use(impl.children(_, bucket, dir, sign)))
+    OptionT(client.use(impl.children(_, bucket, dir)))
       .getOrElseF(IO.raiseError(new Exception("Could not list children under the root")))
       .flatMap(_.compile.toList).map { children =>
         children.length must_== 4


### PR DESCRIPTION
[ch3113]

My original intent was to use [`http4s`'s `FollowRedirect` client middleware](https://github.com/http4s/http4s/blob/v0.19.0/client/src/main/scala/org/http4s/client/middleware/FollowRedirect.scala#L39) to follow the redirects. However, that middleware does not forward query strings, breaking every request made by `FollowRedirect`. In order to try this I had to refactor all the request signing into a client middleware (`AwsV4Signing`). The current implementation does not use `FollowRedirect`, but I decided to keep `AwsV4Signing` since it simplifies stuff.

This is working just fine for `301`s and will probably work for Slalom, but I still need to finish a few things:

- [ ] Handle `301 Moved Permanently` correctly by storing the redirect URI, rather than the original. We have an extra round trip with every request at the moment.
- [ ] Handle more than one redirect. 
- [ ] Handle `302 Found`, `303 See other`, `307 Temporary Redirect`, and `308 Permanent Redirect`.
- [ ] Unit tests for `preflightCheck`.
- [ ] Integration tests.

Depending on urgency, we can either merge as-is and address the TODOs in another PR or we can wait until I finish the remaining TODOs here.